### PR TITLE
Fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Setup your own Dockerfile
 
     EXPOSE 8888
 
-    CMD ["python" "/srv/my-sanic-server.py"]
+    ENTRYPOINT ["python3", "/srv/my-sanic-server.py"]
 
 Build it
 

--- a/base/README.md
+++ b/base/README.md
@@ -19,7 +19,7 @@ Setup your own Dockerfile
 
     EXPOSE 8888
 
-    ENTRYPOINT ["python3" "/srv/my-sanic-server.py"]
+    ENTRYPOINT ["python3", "/srv/my-sanic-server.py"]
 
 Build it
 


### PR DESCRIPTION
ENTRYPOINT and CMD works the same if Dockerfile ends with one command, but executable and params  need separate with a comma